### PR TITLE
Decode HTML entities in titles.

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -150,6 +150,10 @@ def Shows(title, url, thumb):
 
     sortedShows = sorted(shows, key=lambda show: show["name"])
     for show in sortedShows:
+
+        if show["name"] in ('RT Sponsor Cut'):
+            continue
+
         oc.add(
             DirectoryObject(
                 key = Callback(


### PR DESCRIPTION
- I found an `&amp;` in a title that still showed up as `&amp;` in Plex clients.
- The Sponsor Cut section will be skipped.
