### PR TITLE
Added new "Recently Added Videos" option to shows. Fixed some directo…

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -124,7 +124,7 @@ def Shows(url, title):
         oc.add(
             DirectoryObject(
                 key = Callback(
-                    Seasons, 
+                    EpisodeCategories, 
                     title = show["name"],
                     url = show["url"], 
                     thumb = show["img"]
@@ -142,9 +142,44 @@ def Shows(url, title):
     return oc
 
 ##########################################################################################
+@route("/video/roosterteeth/EpisodeCategories")
+def EpisodeCategories(title, url, thumb):
+
+    oc = ObjectContainer(title2=title)
+        
+    oc.add(
+        DirectoryObject(
+            key = Callback(
+                Recents, 
+                title = "Recently Added Videos",
+                url = url,
+                thumb = thumb,
+                xpath_string = "//*[@id='tab-content-trending']//*[@class='episodes--recent']"
+            ), 
+            title = "Recently Added Videos",
+            thumb = thumb
+        )
+    )
+
+    oc.add(
+        DirectoryObject(
+            key = Callback(
+                Seasons, 
+                title = title,
+                url = url, 
+                thumb = thumb
+            ), 
+            title = "Seasons",
+            thumb = thumb
+        )
+    )
+
+    return oc
+
+##########################################################################################
 @route("/video/roosterteeth/Seasons")
 def Seasons(title, url, thumb):
-    oc = ObjectContainer(title2 = title)
+    oc = ObjectContainer(title2="Seasons")
     
     content = HTTP.Request(url).content
     
@@ -204,9 +239,68 @@ def Seasons(title, url, thumb):
         return oc
 
 ##########################################################################################
+@route("/video/roosterteeth/Recents")
+def Recents(title, url, thumb, xpath_string):
+    oc = ObjectContainer(title2=title)
+
+    element = HTML.ElementFromURL(url)
+
+    try:
+        art = element.xpath("//*[@class='cover-image']/@style")[0].split("(")[1].split(")")[0]
+        
+        if art.startswith("//"):
+            art = 'http:' + art 
+    except:
+        art = None
+    
+    episodes = []
+    for item in element.xpath(xpath_string):
+        
+        for episode in item.xpath(".//*[@class='episode-blocks']//li"):
+            url = episode.xpath(".//@href")[0]
+            title = episode.xpath(".//*[@class='name']/text()")[0]
+            thumb = episode.xpath(".//img/@src")[0]
+            
+            if thumb.startswith("//"):
+                thumb = 'http:' + thumb
+                
+            try:
+                index = int(title.split(" ")[1])
+            except:
+                index = None
+                
+            try:
+                duration_string = episode.xpath(".//*[@class='timestamp']/text()")[0].strip()
+                duration = ((int(duration_string.split(":")[0])*60) + int(duration_string.split(":")[1])) * 1000
+            except:
+                duration = None
+            
+            episodes.append(
+                EpisodeObject(
+                    url = url,
+                    title = title,
+                    thumb = thumb,
+                    index = index,
+                    duration = duration,
+                    art = art
+                )
+            )
+    
+    if Prefs['sort'] == 'Latest First':
+        for episode in episodes:
+            oc.add(episode)   
+    else:
+        for episode in reversed(episodes):
+            oc.add(episode)
+        
+    return oc
+
+
+
+##########################################################################################
 @route("/video/roosterteeth/Items")
 def Items(title, url, thumb, xpath_string, art, id=None):
-    oc = ObjectContainer()
+    oc = ObjectContainer(title2=title)
 
     element = HTML.ElementFromURL(url)
     


### PR DESCRIPTION
Added new "Recently Added Videos" option to shows. Fixed some directory title bugs.

Came across this this morning after a couple weeks of trying to find a good way to watch RT content on my TV. What a coincidence?

I did notice, though, that some shows don't add the Sponsor early release content to the episode list right away, but they DO show up in the recently added list. So I went ahead and added an option to the Shows directory. Let me know if you want to make any changes to this or if you don't want to merge it in, etc.

Oh and I found some directory naming title bugs, fixed those too.