### PR TITLE
Repairing login by setting default to roosterteeth. fixes #10, fixes #7

### DIFF
--- a/Contents/Services/Shared Code/roosterteeth.pys
+++ b/Contents/Services/Shared Code/roosterteeth.pys
@@ -1,10 +1,11 @@
 ##########################################################################################
-def Login(url):
+def Login(url='https://roosterteeth.com/login'):
 
     Log("Attempting to login ...")
     
-    login_url = 'https://roosterteeth.com/login'
-    if 'achievementhunter' in url:
+    if 'roosterteeth' in url:
+        login_url = 'https://roosterteeth.com/login'
+    elif 'achievementhunter' in url:
         login_url = 'https://achievementhunter.com/login'
     elif 'funhaus' in url:
         login_url = 'https://funhaus.com/login'


### PR DESCRIPTION
With this watching First only content works at least for RoosterTeeth and Achievement Hunter.
I tested with watching Theater Mode: Episode #23: Fertilize The Blaspheming Bombshell and Rooster Teeth Podcast: College Drama Failure - #453 Post Show both worked.

'https://roosterteeth.com/login' was set by default, but newer used so I just added it really to default.

fixes #10 
fixes #7 